### PR TITLE
user-defined sgx attestation type

### DIFF
--- a/ecc_enclave/sgxcclib/CMakeLists.txt
+++ b/ecc_enclave/sgxcclib/CMakeLists.txt
@@ -1,3 +1,5 @@
+INCLUDE(CMakeVariables.txt)
+
 set(SOURCE_FILES
     sgxcclib.c
     enclave_u.c
@@ -29,7 +31,7 @@ include_directories(
     ${SGX_SDK}/include
     )
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SGX_COMMON_CFLAGS} -fPIC -Wall -Wno-attributes -std=c11")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SGX_COMMON_CFLAGS} -fPIC -Wall -Wno-attributes -std=c11 ${SGX_ATTESTATION_FLAG}")
 
 set_target_properties(libsgxcc PROPERTIES PREFIX "")
 

--- a/ecc_enclave/sgxcclib/CMakeVariables.txt
+++ b/ecc_enclave/sgxcclib/CMakeVariables.txt
@@ -1,0 +1,29 @@
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SET(ECC_ATTESTATION_TYPE "$ENV{ECC_ATTESTATION_TYPE}")
+
+IF("$ENV{ECC_ATTESTATION_TYPE} " STREQUAL " ")
+    #default attestation flag is "epid_unlikable"
+    SET(SGX_ATTESTATION_FLAG "-DUSE_EPID_UNLINKABLE")
+ELSE()
+    IF("${ECC_ATTESTATION_TYPE} " STREQUAL "epid_linkable ")
+        SET(SGX_ATTESTATION_FLAG "-DUSE_EPID_LINKABLE")
+    ELSEIF("${ECC_ATTESTATION_TYPE} " STREQUAL "epid_unlinkable ")
+        SET(SGX_ATTESTATION_FLAG "-DUSE_EPID_UNLINKABLE")
+    ELSE()
+        message(FATAL_ERROR "if set, ECC_ATTESTATION_TYPE must be 'epid_linkable' or 'epid_unlinkable'")
+    ENDIF()
+ENDIF()
+

--- a/ecc_enclave/sgxcclib/sgx_attestation_type.h
+++ b/ecc_enclave/sgxcclib/sgx_attestation_type.h
@@ -1,0 +1,30 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "sgx_quote.h"
+
+#ifdef USE_EPID_LINKABLE
+
+#define SGX_QUOTE_SIGN_TYPE SGX_LINKABLE_SIGNATURE
+
+#endif
+
+
+#ifdef USE_EPID_UNLINKABLE
+
+#define SGX_QUOTE_SIGN_TYPE SGX_UNLINKABLE_SIGNATURE
+
+#endif
+

--- a/ecc_enclave/sgxcclib/sgxcclib.c
+++ b/ecc_enclave/sgxcclib/sgxcclib.c
@@ -146,7 +146,7 @@ int sgxcc_get_remote_attestation_report(
         return SGX_ERROR_OUT_OF_MEMORY;
     }
 
-    ret = sgx_get_quote(&report, SGX_UNLINKABLE_SIGNATURE,
+    ret = sgx_get_quote(&report, SGX_QUOTE_SIGN_TYPE,
         (sgx_spid_t *)spid,  // spid
         NULL,                // nonce
         NULL,                // sig_rl

--- a/ecc_enclave/sgxcclib/sgxcclib.h
+++ b/ecc_enclave/sgxcclib/sgxcclib.h
@@ -18,6 +18,7 @@
 #define _SGXCCLIB_H_
 
 #include "types.h"
+#include "sgx_attestation_type.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
the user can define the TCC_ATTESTATION_TYPE environment variable as "linkable" or "unlinkable".
When not defined the default behavior is "unlinkable" -- it preserves backward compatibility.


Signed-off-by: Bruno Vavala <bruno.vavala@intel.com>